### PR TITLE
fix(host): improve header iteration and display formatting

### DIFF
--- a/examples/info.rs
+++ b/examples/info.rs
@@ -16,9 +16,9 @@ impl Guest for Plugin {
     /// Handles incoming requests by logging metadata and headers.
     fn handle_request(&self, request: &Request, _response: &Response) -> (bool, i32) {
         info!("Request: {} {} {} {}", request.method(), request.version(), request.uri(), request.source_addr());
-        for name in request.header().names_iter() {
-            let values = request.header().values_iter(&name).map(|v| v.to_str().unwrap_or("-").to_string());
-            info!("Header: {} [{}]", name, values.collect::<Vec<_>>().join(", "));
+        for (name, values) in request.header().entries_iter() {
+            let values = values.iter().map(|v| format!("{v}")).collect::<Vec<_>>().join(", ");
+            info!("Header: {} [{}]", name, values);
         }
         info!("Body: {}", request.body().read());
         (true, 0)

--- a/src/host/bytes.rs
+++ b/src/host/bytes.rs
@@ -4,6 +4,7 @@ use std::{
     ops::Deref,
     str::{Utf8Error, from_utf8},
 };
+
 /// Owned container for binary data used throughout the API.
 ///
 /// `Bytes` stores its contents as a boxed slice for efficient cloning and
@@ -14,6 +15,8 @@ use std::{
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Hash, Default)]
 pub struct Bytes(Box<[u8]>);
 
+// --- Core API Methods ---
+
 impl Bytes {
     /// Returns the contents as UTF-8 if valid.
     ///
@@ -23,6 +26,9 @@ impl Bytes {
         from_utf8(&self.0)
     }
 }
+
+// --- Standard Library Trait Implementations (for Bytes) ---
+
 impl Deref for Bytes {
     type Target = [u8];
 
@@ -33,11 +39,7 @@ impl Deref for Bytes {
 
 impl Display for Bytes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self.to_str() {
-            Ok(res) => res,
-            Err(err) => &err.to_string(),
-        };
-        write!(f, "{}", &s)
+        write!(f, "{}", String::from_utf8_lossy(&self.0))
     }
 }
 
@@ -55,6 +57,8 @@ impl<const N: usize> Borrow<[u8; N]> for Bytes {
         unsafe { &*(self.as_ref() as *const [u8] as *const [u8; N]) }
     }
 }
+
+// --- Comparison Trait Implementations ---
 
 impl<const N: usize> PartialEq<[u8; N]> for Bytes {
     fn eq(&self, other: &[u8; N]) -> bool {
@@ -74,12 +78,7 @@ impl<const N: usize> PartialEq<&[u8; N]> for Bytes {
     }
 }
 
-// impl<const N: usize> PartialEq<Bytes> for &[u8; N] {
-//     fn eq(&self, other: &Bytes) -> bool {
-//         *self == other.as_ref()
-//     }
-// }
-
+// Helper trait implementations
 impl PartialEq<str> for Bytes {
     fn eq(&self, other: &str) -> bool {
         match self.to_str() {
@@ -103,6 +102,8 @@ impl PartialEq<Bytes> for str {
         self.as_bytes() == other.as_ref()
     }
 }
+
+// --- Conversion Trait Implementations (From<...> for Bytes) ---
 
 /// Creates a `Bytes` value from an existing boxed slice without copying.
 impl From<Box<[u8]>> for Bytes {
@@ -143,10 +144,25 @@ impl From<&str> for Bytes {
     }
 }
 
+// --- Test Module ---
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    #[test]
+    fn test_display_valid_utf8() {
+        let s = "valid";
+        let b = Bytes::from(s);
+        assert_eq!(format!("{b}"), s);
+    }
+
+    #[test]
+    fn test_display_invalid_utf8() {
+        let b = Bytes::from(vec![0x48, 0xFF, 0x6c, 0x6c, 0x6f]);
+        assert_eq!(format!("{b}"), "H�llo");
+    }
 
     #[test]
     fn bytes_from_string_slice_roundtrip() {

--- a/src/host/header.rs
+++ b/src/host/header.rs
@@ -17,14 +17,16 @@ impl Header {
         Self(kind)
     }
 
-    /// Return all header names as raw bytes without allocating into a vector.
+    /// Returns an iterator over all header names as raw bytes without allocating into a vector.
     ///
     /// Header names are returned in the order provided by the host runtime.
+    /// This method is zero-allocation and returns an iterator that yields each
+    /// header name as `Bytes`. For heap-allocated results, use [`names`](Header::names).
     pub fn names_iter(&self) -> impl Iterator<Item = Bytes> + use<'_> {
         handler::header_names(self.0).into_iter().map(Bytes::from)
     }
 
-    /// Return all header names as raw bytes, allocating into a vector.
+    /// Returns all header names as raw bytes, allocating into a vector.
     ///
     /// Header names are returned in the order provided by the host runtime.
     /// This method collects results into a `Vec`, which allocates heap memory.
@@ -33,10 +35,12 @@ impl Header {
         self.names_iter().collect()
     }
 
-    /// Return all values for the given header name without allocating into a vector.
+    /// Returns an iterator over all values for the given header name without allocating into a vector.
     ///
     /// The `name` is matched by the host according to its header normalization
-    /// rules (often case-insensitive).
+    /// rules (often case-insensitive). This method is zero-allocation and returns
+    /// an iterator that yields each header value as `Bytes`. For heap-allocated results,
+    /// use [`values`](Header::values).
     pub fn values_iter(&self, name: &[u8]) -> impl Iterator<Item = Bytes> + use<'_> {
         handler::header_values(self.0, name).into_iter().map(Bytes::from)
     }
@@ -46,7 +50,7 @@ impl Header {
         self.values_iter(name).next()
     }
 
-    /// Return all values for the given header name, allocating into a vector.
+    /// Returns all values for the given header name, allocating into a vector.
     ///
     /// The `name` is matched by the host according to its header normalization
     /// rules (often case-insensitive). This method collects results into a `Vec`,
@@ -71,14 +75,15 @@ impl Header {
         handler::remove_header(self.0, name);
     }
 
-    /// Return all headers as an iterator of names to value iterators.
+    /// Return all headers as an iterator of names to value lists.
     ///
-    /// This avoids allocating into a `HashMap` and `Vec` by providing lazy
-    /// evaluation through iterators. Each entry contains the header name paired
-    /// with an iterator over its values.
-    pub fn entries_iter(&self) -> impl Iterator<Item = (Bytes, impl Iterator<Item = Bytes>)> + '_ {
+    /// This returns an iterator over all header entries. Each entry contains
+    /// the header name paired with a vector containing its associated values.
+    /// For zero-allocation access, use [`names_iter`](Header::names_iter) and
+    /// [`values_iter`](Header::values_iter).
+    pub fn entries_iter(&self) -> impl Iterator<Item = (Bytes, Vec<Bytes>)> + '_ {
         self.names_iter().map(|name| {
-            let values = self.values_iter(&name);
+            let values: Vec<Bytes> = self.values_iter(&name).collect();
             (name, values)
         })
     }
@@ -90,12 +95,7 @@ impl Header {
     /// paired with a vector containing its associated values. Use
     /// [`entries_iter`](Header::entries_iter) for zero-allocation access.
     pub fn entries(&self) -> HashMap<Bytes, Vec<Bytes>> {
-        self.names_iter()
-            .map(|name| {
-                let values = self.values_iter(&name).collect::<Vec<Bytes>>();
-                (name, values)
-            })
-            .collect()
+        self.entries_iter().collect()
     }
 }
 


### PR DESCRIPTION
This commit refactors the header handling in the host API to provide better iterator support and more consistent display formatting. The changes include:

- Updating `entries_iter` to return Vec<Bytes> instead of lazy iterators for easier consumption
- Improving documentation for all header iteration methods
- Simplifying the Display implementation for Bytes by using String::from_utf8_lossy
- Adding tests to verify proper UTF-8 handling in display formatting