### PR TITLE
ci: Update clippy command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Preflight - clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all --all-features
 
       - name: Preflight - package manifest
         run: cargo package --list


### PR DESCRIPTION
Adjusts the `cargo clippy` command in `.github/workflows/release.yml` to use `--all` instead of `--all-targets` when running preflight checks.